### PR TITLE
#109 Redrawing text elements throws an exception in IE8

### DIFF
--- a/src/core/selection-style.js
+++ b/src/core/selection-style.js
@@ -23,12 +23,12 @@ d3_selectionPrototype.style = function(name, value, priority) {
 
     // For style(string), return the computed style value for the first node.
     if (n < 2) {
-      if (this.node().paper) {
+      if (this.node() && this.node().paper) {
         return this.node().raphaelNode.attr(name);
       } else {
         return window.getComputedStyle(this.node(), null)
                      .getPropertyValue(name);
-      } 
+      }
     }
 
     // For style(string, string) or style(string, function), use the default
@@ -69,7 +69,7 @@ function d3_selection_style(name, value, priority) {
     var x = value.apply(this, arguments);
     if (x == null) {
       if (this.paper) {
-        this.removeStyleProperty(name); 
+        this.removeStyleProperty(name);
       } else {
         this.style.removeProperty(name);
       }

--- a/src/core/selection-text.js
+++ b/src/core/selection-text.js
@@ -1,7 +1,7 @@
 d3_selectionPrototype.text = function(value) {
 
   // For raphael elements get/set text through paper.
-  if (this.node().paper) {
+  if (this.node() && this.node().paper) {
     return arguments.length < 1
         ? this.node().getAttribute('text') : this.each(typeof value === "function"
         ? function() { var v = value.apply(this, arguments); this.setAttribute('text', v == null ? "" : v); } : value == null


### PR DESCRIPTION
Fixed the issue by adding a check to see that this.node() exists before doing any operation on it.
