### PR TITLE
Updated Object.create to a more compatibile version

### DIFF
--- a/lib/compat/compat.js
+++ b/lib/compat/compat.js
@@ -242,12 +242,26 @@ if(!document.createElementNS) {
 
 
 if (!Object.create) {
-    Object.create = function (o) {
-        if (arguments.length > 1) {
-            throw new Error('Object.create implementation only accepts the first parameter.');
+    Object.create = function(prototype, properties) {
+        // from es5-shim
+        var object;
+        if (prototype === null) {
+            object = {
+                '__proto__': null
+            };
+        } else {
+            if (typeof prototype !== 'object') {
+                throw new TypeError(
+                    'typeof prototype[' + (typeof prototype) + '] != \'object\'');
+            }
+            var Type = function() {};
+            Type.prototype = prototype;
+            object = new Type();
+            object.__proto__ = prototype;
         }
-        function F() {}
-        F.prototype = o;
-        return new F();
+        if (typeof properties !== 'undefined' && Object.defineProperties) {
+            Object.defineProperties(object, properties);
+        }
+        return object;
     };
 }


### PR DESCRIPTION
Old Object.create code might cause problems with some libraries e.g. browserify
